### PR TITLE
added analogFastWrite

### DIFF
--- a/Mechaduino_01/Mechaduino_01/Mechaduino_01.ino
+++ b/Mechaduino_01/Mechaduino_01/Mechaduino_01.ino
@@ -46,6 +46,7 @@
 #include "Utils.h"
 #include "Parameters.h"
 #include "state.h"
+#include "analogFastWrite.h"
 
 //////////////////////////////////////
 /////////////////SETUP////////////////

--- a/Mechaduino_01/Mechaduino_01/Utils.cpp
+++ b/Mechaduino_01/Mechaduino_01/Utils.cpp
@@ -8,7 +8,7 @@
 #include "Controller.h"
 #include "Utils.h"
 #include "State.h"
-
+#include "analogFastWrite.h"
 
 void setupPins() {
 
@@ -29,8 +29,8 @@ void setupPins() {
 
 
 
-  analogWrite(VREF_2, 64);
-  analogWrite(VREF_1, 64);
+  analogFastWrite(VREF_2, 64);
+  analogFastWrite(VREF_1, 64);
 
   digitalWrite(IN_4, HIGH);
   digitalWrite(IN_3, LOW);
@@ -87,7 +87,7 @@ void output(float theta, int effort) {                    //////////////////////
   //  modangle = (((intangle % 628) + 628) % 628);
   val1 = effort * lookup_sine(intangle);
 
-  analogWrite(VREF_2, abs(val1));
+  analogFastWrite(VREF_2, abs(val1));
 
   if (val1 >= 0)  {
     digitalWrite(IN_4, HIGH);
@@ -115,7 +115,7 @@ void output(float theta, int effort) {                    //////////////////////
   // modangle = (((intangle % 628) + 628) % 628);
   val2 = effort * lookup_sine(intangle);
 
-  analogWrite(VREF_1, abs(val2));
+  analogFastWrite(VREF_1, abs(val2));
 
   if (val2 >= 0)  {
     digitalWrite(IN_2, HIGH);

--- a/Mechaduino_01/Mechaduino_01/analogFastWrite.c
+++ b/Mechaduino_01/Mechaduino_01/analogFastWrite.c
@@ -1,0 +1,195 @@
+
+#include "Arduino.h"
+#include "wiring_private.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static int _readResolution = 10;
+static int _ADCResolution = 10;
+static int _writeResolution = 8;
+
+// Wait for synchronization of registers between the clock domains
+static __inline__ void syncADC() __attribute__((always_inline, unused));
+static void syncADC() {
+  while (ADC->STATUS.bit.SYNCBUSY == 1)
+    ;
+}
+
+// Wait for synchronization of registers between the clock domains
+static __inline__ void syncDAC() __attribute__((always_inline, unused));
+static void syncDAC() {
+  while (DAC->STATUS.bit.SYNCBUSY == 1)
+    ;
+}
+
+// Wait for synchronization of registers between the clock domains
+static __inline__ void syncTC_8(Tc* TCx) __attribute__((always_inline, unused));
+static void syncTC_8(Tc* TCx) {
+  while (TCx->COUNT8.STATUS.bit.SYNCBUSY);
+}
+
+// Wait for synchronization of registers between the clock domains
+static __inline__ void syncTCC(Tcc* TCCx) __attribute__((always_inline, unused));
+static void syncTCC(Tcc* TCCx) {
+  while (TCCx->SYNCBUSY.reg & TCC_SYNCBUSY_MASK);
+}
+
+
+static inline uint32_t mapResolution(uint32_t value, uint32_t from, uint32_t to)
+{
+  if (from == to) {
+    return value;
+  }
+  if (from > to) {
+    return value >> (from-to);
+  }
+  return value << (to-from);
+}
+
+/*
+ * Internal Reference is at 1.0v
+ * External Reference should be between 1v and VDDANA-0.6v=2.7v
+ *
+ * Warning : On Arduino Zero board the input/output voltage for SAMD21G18 is 3.3 volts maximum
+ */
+
+
+
+// Right now, PWM output only works on the pins with
+// hardware support.  These are defined in the appropriate
+// pins_*.c file.  For the rest of the pins, we default
+// to digital output.
+void analogFastWrite(uint32_t pin, uint32_t value)
+{
+  PinDescription pinDesc = g_APinDescription[pin];
+  uint32_t attr = pinDesc.ulPinAttribute;
+
+  if ((attr & PIN_ATTR_ANALOG) == PIN_ATTR_ANALOG)
+  {
+    // DAC handling code
+
+    if (pin != PIN_A0) { // Only 1 DAC on A0 (PA02)
+      return;
+    }
+
+    value = mapResolution(value, _writeResolution, 10);
+
+    syncDAC();
+    DAC->DATA.reg = value & 0x3FF;  // DAC on 10 bits.
+    syncDAC();
+    DAC->CTRLA.bit.ENABLE = 0x01;     // Enable DAC
+    syncDAC();
+    return;
+  }
+
+  if ((attr & PIN_ATTR_PWM) == PIN_ATTR_PWM)
+  {
+    value = mapResolution(value, _writeResolution, 8);
+
+    uint32_t tcNum = GetTCNumber(pinDesc.ulPWMChannel);
+    uint8_t tcChannel = GetTCChannelNumber(pinDesc.ulPWMChannel);
+    static bool tcEnabled[TCC_INST_NUM+TC_INST_NUM];
+
+    if (!tcEnabled[tcNum]) {
+      tcEnabled[tcNum] = true;
+
+      if (attr & PIN_ATTR_TIMER) {
+        #if !(ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10603)
+        // Compatibility for cores based on SAMD core <=1.6.2
+        if (pinDesc.ulPinType == PIO_TIMER_ALT) {
+          pinPeripheral(pin, PIO_TIMER_ALT);
+        } else
+        #endif
+        {
+          pinPeripheral(pin, PIO_TIMER);
+        }
+      } else {
+        // We suppose that attr has PIN_ATTR_TIMER_ALT bit set...
+        pinPeripheral(pin, PIO_TIMER_ALT);
+      }
+
+      uint16_t GCLK_CLKCTRL_IDs[] = {
+        GCLK_CLKCTRL_ID(GCM_TCC0_TCC1), // TCC0
+        GCLK_CLKCTRL_ID(GCM_TCC0_TCC1), // TCC1
+        GCLK_CLKCTRL_ID(GCM_TCC2_TC3),  // TCC2
+        GCLK_CLKCTRL_ID(GCM_TCC2_TC3),  // TC3
+        GCLK_CLKCTRL_ID(GCM_TC4_TC5),   // TC4
+        GCLK_CLKCTRL_ID(GCM_TC4_TC5),   // TC5
+        GCLK_CLKCTRL_ID(GCM_TC6_TC7),   // TC6
+        GCLK_CLKCTRL_ID(GCM_TC6_TC7),   // TC7
+      };
+      GCLK->CLKCTRL.reg = (uint16_t) (GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_IDs[tcNum]);
+      while (GCLK->STATUS.bit.SYNCBUSY == 1);
+
+      // Set PORT
+      if (tcNum >= TCC_INST_NUM) {
+        // -- Configure TC
+        Tc* TCx = (Tc*) GetTC(pinDesc.ulPWMChannel);
+        // Disable TCx
+        TCx->COUNT8.CTRLA.bit.ENABLE = 0;
+        syncTC_8(TCx);
+        // Set Timer counter Mode to 8 bits, normal PWM
+        TCx->COUNT8.CTRLA.reg |= TC_CTRLA_MODE_COUNT8 | TC_CTRLA_WAVEGEN_NPWM;
+        syncTC_8(TCx);
+        // Set the initial value
+        TCx->COUNT8.CC[tcChannel].reg = (uint8_t) value;
+        syncTC_8(TCx);
+        // Set PER to maximum counter value (resolution : 0xFF)
+        TCx->COUNT8.PER.reg = 0xFF;
+        syncTC_8(TCx);
+        // Enable TCx
+        TCx->COUNT8.CTRLA.bit.ENABLE = 1;
+        syncTC_8(TCx);
+      } else {
+        // -- Configure TCC
+        Tcc* TCCx = (Tcc*) GetTC(pinDesc.ulPWMChannel);
+        // Disable TCCx
+        TCCx->CTRLA.bit.ENABLE = 0;
+        syncTCC(TCCx);
+
+        // Set TCx as normal PWM
+        TCCx->WAVE.reg |= TCC_WAVE_WAVEGEN_NPWM;
+        syncTCC(TCCx);
+        // Set the initial value
+        TCCx->CC[tcChannel].reg = (uint32_t) value;
+        syncTCC(TCCx);
+        // Set PER to maximum counter value (resolution : 0xFF)
+        TCCx->PER.reg = 0xFF;
+        syncTCC(TCCx);
+        // Enable TCCx
+        TCCx->CTRLA.bit.ENABLE = 1;
+        syncTCC(TCCx);
+      }
+    } else {
+      if (tcNum >= TCC_INST_NUM) {
+        Tc* TCx = (Tc*) GetTC(pinDesc.ulPWMChannel);
+        TCx->COUNT8.CC[tcChannel].reg = (uint8_t) value;
+        syncTC_8(TCx);
+    } else {
+        Tcc* TCCx = (Tcc*) GetTC(pinDesc.ulPWMChannel);
+        TCCx->CTRLBSET.bit.LUPD = 1;
+        syncTCC(TCCx);
+        TCCx->CCB[tcChannel].reg = (uint32_t) value;
+        syncTCC(TCCx);
+        TCCx->CTRLBCLR.bit.LUPD = 1;
+        syncTCC(TCCx);
+      }
+    }
+    return;
+  }
+
+  // -- Defaults to digital write
+  pinMode(pin, OUTPUT);
+  value = mapResolution(value, _writeResolution, 8);
+  if (value < 128) {
+    digitalWrite(pin, LOW);
+  } else {
+    digitalWrite(pin, HIGH);
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/Mechaduino_01/Mechaduino_01/analogFastWrite.h
+++ b/Mechaduino_01/Mechaduino_01/analogFastWrite.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * \brief SAMD products have only one reference for ADC
+ */
+
+
+extern void analogFastWrite( uint32_t ulPin, uint32_t ulValue ) ;
+
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
The latest arduino zero board files (1.6.7 and up) have a much lower PWM frequency than previous versions (732.4Hz , down from 187.5kHz).  This causes audible hissing when used with the Mechaduino.  We added the analogFastWrite command to provide 187.5kHz PWM to eliminate this issue.
