### PR TITLE
Fixes compilation errors.

### DIFF
--- a/Mechaduino_01/Mechaduino_01/Mechaduino_01.ino
+++ b/Mechaduino_01/Mechaduino_01/Mechaduino_01.ino
@@ -42,6 +42,8 @@
 #include "Parameters.h"
 #include "State.h"
 #include "analogFastWrite.h"
+#include "SPI.h"
+#include "Wire.h"
 
 //////////////////////////////////////
 /////////////////SETUP////////////////

--- a/Mechaduino_01/Mechaduino_01/Parameters.h
+++ b/Mechaduino_01/Mechaduino_01/Parameters.h
@@ -17,8 +17,7 @@ extern volatile float vKp;
 extern volatile float vKi;
 extern volatile float vKd;
 
-extern const PROGMEM float lookup[];
-
+extern const float lookup[];
 
 extern const int spr; //  200 steps per revolution
 extern const float aps; // angle per step
@@ -49,13 +48,9 @@ extern const int chipSelectPin;
 extern const int step_pin;
 extern const int dir_pin;
 
-
-
-
-extern const PROGMEM float force_lookup[];
+extern const float force_lookup[];
 
 extern  int sin_1[3600];
-
 
 #endif
 


### PR DESCRIPTION
When compiling the sketch, errors regarding two missing includes and an undefined type showed up. This commit adds the missing includes to the .ino file, and removes the PROGMEM definitions from Parameters.h, since PROGMEM is apparently only supported on AVR hardware.

Reported-by: Razaekel
Signed-off-by: Razaekel <ubersentinel@gmail.com>

Closes #17 